### PR TITLE
Remove defaults from environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: normits_lu
 channels:
-  - defaults
   - conda-forge
 dependencies:
   - caf.toolkit>=0.0.7


### PR DESCRIPTION
Miniforge was struggling to create the environment when it had both 'defaults' and 'conda-forge' as channels. Removing 'defaults' resolved this. Questions with the dependencies wide ranging version acceptance remain.